### PR TITLE
tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,24 @@ branches:
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-tornado
+      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore
     - python: 2.7
-      env: TOXENV=py27-twisted
+      env: TOXENV=py27-tornado MONOCLE_STACK=tornado
     - python: 2.7
-      env: TOXENV=py27-coverage
+      env: TOXENV=py27-twisted MONOCLE_STACK=twisted
     - python: 2.6
-      env: TOXENV=py26-tornado
+      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore
     - python: 2.6
-      env: TOXENV=py26-twisted
+      env: TOXENV=py26-tornado MONOCLE_STACK=tornado
+    - python: 2.6
+      env: TOXENV=py26-twisted MONOCLE_STACK=twisted
     - python: pypy
-      env: TOXENV=pypy-tornado
+      env: TOXENV=pypy-tornado MONOCLE_STACK=tornado
+  allow_failures:
+    - python: 2.7
+      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore
+    - python: 2.6
+      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore
 
 cache:
   - apt
@@ -32,3 +39,7 @@ install:
 
 script:
   - tox
+
+after_success:
+  - source .tox/py27-${MONOCLE_STACK}/bin/activate && py.test -q --confcutdir=.. -n 1 --junitxml=tests/junit.xml --cov-report xml --cov monocle --cov-report=html --cov-report term-missing --pep8
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,34 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "pypy"
-env:
-  - BACKEND=tornado
-  - BACKEND=twisted
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libssl-dev
-install:
-  - pip install pyOpenSSL $BACKEND --use-mirrors
-  - pip install . --use-mirrors
-  - pip install pytest
-script:
-  - python examples/basics.py $BACKEND
-  - python examples/client_server.py $BACKEND
-  - python examples/sleep.py $BACKEND
-  - python examples/tb.py $BACKEND
-  - python o_test.py -v $BACKEND tests/
+sudo: false
+branches:
+  except:
+    - gh-pages
 
 matrix:
-  exclude:
-    - python: "pypy"
+  include:
+    - python: 2.7
+      env: TOXENV=py27-tornado
+    - python: 2.7
+      env: TOXENV=py27-twisted
+    - python: 2.7
+      env: TOXENV=py27-coverage
+    - python: 2.6
+      env: TOXENV=py26-tornado
+    - python: 2.6
+      env: TOXENV=py26-twisted
+    - python: pypy
+      env: TOXENV=pypy-tornado
+
+cache:
+  - apt
+
+addons:
+  apt:
+    packages:
+      - libssl-dev
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,50 @@
+[tox]
+envlist =
+    py27-{twisted,tornado,coverage}
+    py26-{twisted,tornado}
+    pypy-tornado
+skipsdist = True
+
+[pytest]
+python_files=test_*.py
+
+[testenv]
+deps =
+    pyOpenSSL
+    pypy: cryptography==0.9.3
+    tornado: tornado
+    twisted: twisted
+usedevelop = True
+
+commands =
+    python examples/basics.py $BACKEND
+    python examples/client_server.py $BACKEND
+    python examples/sleep.py $BACKEND
+    python examples/tb.py $BACKEND
+    python o_test.py -v $BACKEND tests/
+
+[testenv:tornado]
+setenv =
+    BACKEND = tornado
+
+[testenv:twisted]
+setenv =
+    BACKEND = twisted
+
+[testenv:coverage]
+deps =
+    pyOpenSSL
+    pytest
+    pytest-cov
+    pytest-pep8
+    pytest-xdist
+    twisted
+
+commands =
+    py.test -q --basetemp={envtmpdir} --confcutdir=.. -n 1 \
+        --junitxml=tests/junit.xml \
+        --cov-report xml --cov monocle \
+        --cov-report=html \
+        --cov-report term-missing \
+        --pep8 \
+        {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py27-{twisted,tornado,coverage}
-    py26-{twisted,tornado}
+    py27-{twisted,tornado,asyncore,coverage}
+    py26-{twisted,tornado,asyncore}
     pypy-tornado
 skipsdist = True
 
@@ -9,42 +9,34 @@ skipsdist = True
 python_files=test_*.py
 
 [testenv]
+passenv = MONOCLE_STACK
 deps =
-    pyOpenSSL
     pypy: cryptography==0.9.3
     tornado: tornado
     twisted: twisted
-usedevelop = True
-
-commands =
-    python examples/basics.py $BACKEND
-    python examples/client_server.py $BACKEND
-    python examples/sleep.py $BACKEND
-    python examples/tb.py $BACKEND
-    python o_test.py -v $BACKEND tests/
-
-[testenv:tornado]
-setenv =
-    BACKEND = tornado
-
-[testenv:twisted]
-setenv =
-    BACKEND = twisted
-
-[testenv:coverage]
-deps =
     pyOpenSSL
     pytest
     pytest-cov
     pytest-pep8
     pytest-xdist
-    twisted
+
+usedevelop = True
 
 commands =
-    py.test -q --basetemp={envtmpdir} --confcutdir=.. -n 1 \
-        --junitxml=tests/junit.xml \
-        --cov-report xml --cov monocle \
-        --cov-report=html \
-        --cov-report term-missing \
-        --pep8 \
-        {posargs}
+    python o_test.py -v {env:MONOCLE_STACK} tests/
+    python examples/basics.py {env:MONOCLE_STACK}
+    python examples/client_server.py {env:MONOCLE_STACK}
+    python examples/sleep.py {env:MONOCLE_STACK}
+    python examples/tb.py {env:MONOCLE_STACK}
+
+[testenv:asyncore]
+setenv =
+    MONOCLE_STACK = asyncore
+
+[testenv:tornado]
+setenv =
+    MONOCLE_STACK = tornado
+
+[testenv:twisted]
+setenv =
+    MONOCLE_STACK = twisted


### PR DESCRIPTION
- use [tox](https://tox.readthedocs.org/en/latest/) to manage py27, py26 and pypy virtual environments and as the test command line tool
- moved environment setup from `.travis.yml` to `tox.ini`
- install `libssl-dev` apt package through [travis-ci](https://travis-ci.org/) `add ons:apt:packages` section
- set `sudo=false` to use [travis-ci](https://travis-ci.org/) container infrastructure
- cache installation of apt packages on [travis-ci](https://travis-ci.org/) environment
- added code coverage report with ability to integrate with [coveralls.io](https://coveralls.io/)