### PR TITLE
Better importing for dev use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pyc
 .DS_Store
 .coverage
+monocle.egg-info

--- a/monocle/__init__.py
+++ b/monocle/__init__.py
@@ -3,7 +3,7 @@ import sys
 import core
 from core import _o, o, launch, Return, InvalidYieldException, log_exception
 
-VERSION = '0.35'
+VERSION = '0.36'
 
 _stack_name = None
 def init(stack_name):

--- a/monocle/stack/eventloop.py
+++ b/monocle/stack/eventloop.py
@@ -1,7 +1,13 @@
 import monocle
-if monocle._stack_name == 'twisted':
+import os
+if monocle._stack_name == 'twisted' or os.getenv('MONOCLE_STACK') == 'twisted':
     from monocle.twisted_stack.eventloop import *
-elif monocle._stack_name == 'tornado':
+elif monocle._stack_name == 'tornado' or os.getenv('MONOCLE_STACK') == 'tornado':
     from monocle.tornado_stack.eventloop import *
-elif monocle._stack_name == 'asyncore':
+elif monocle._stack_name == 'asyncore' or os.getenv('MONOCLE_STACK') == 'asyncore':
     from monocle.asyncore_stack.eventloop import *
+else:
+    raise ImportError(
+        "Could not import stack.\n"
+        "Ensure you have called monocle.init()\n"
+        "or defined MONOCLE_STACK=<stack> in the environment")


### PR DESCRIPTION
 - More explicit error message
 - Allow setting the stack in the environment
 - gitignore products of `pip install -e .`