### PR TITLE
travis-ci fails build on python2.6+twisted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 2.6
       env: TOXENV=py26-tornado MONOCLE_STACK=tornado
     - python: 2.6
-      env: TOXENV=py26-twisted MONOCLE_STACK=twisted
+      env: TOXENV=py26-twisted26 MONOCLE_STACK=twisted
     - python: pypy
       env: TOXENV=pypy-tornado MONOCLE_STACK=tornado
   allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-{twisted,tornado,asyncore,coverage}
-    py26-{twisted,tornado,asyncore}
+    py26-{twisted26,tornado,asyncore}
     pypy-tornado
 skipsdist = True
 
@@ -14,6 +14,7 @@ deps =
     pypy: cryptography==0.9.3
     tornado: tornado
     twisted: twisted
+    twisted26: twisted<15.5.0
     pyOpenSSL
     pytest
     pytest-cov


### PR DESCRIPTION
twisted stopped supporting python2.6 on release >= 15.5.0.