### PR TITLE
after_success success always fails on python26 environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 2.6
       env: TOXENV=py26-tornado MONOCLE_STACK=tornado
     - python: 2.6
-      env: TOXENV=py26-twisted MONOCLE_STACK=twisted
+      env: TOXENV=py26-twisted26 MONOCLE_STACK=twisted
     - python: pypy
       env: TOXENV=pypy-tornado MONOCLE_STACK=tornado
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,24 @@ branches:
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore
+      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=27
     - python: 2.7
-      env: TOXENV=py27-tornado MONOCLE_STACK=tornado
+      env: TOXENV=py27-tornado MONOCLE_STACK=tornado PYTHON_VERSION=27
     - python: 2.7
-      env: TOXENV=py27-twisted MONOCLE_STACK=twisted
+      env: TOXENV=py27-twisted MONOCLE_STACK=twisted PYTHON_VERSION=27
     - python: 2.6
-      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore
+      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=26
     - python: 2.6
-      env: TOXENV=py26-tornado MONOCLE_STACK=tornado
+      env: TOXENV=py26-tornado MONOCLE_STACK=tornado PYTHON_VERSION=26
     - python: 2.6
-      env: TOXENV=py26-twisted26 MONOCLE_STACK=twisted
+      env: TOXENV=py26-twisted26 MONOCLE_STACK=twisted PYTHON_VERSION=26
     - python: pypy
-      env: TOXENV=pypy-tornado MONOCLE_STACK=tornado
+      env: TOXENV=pypy-tornado MONOCLE_STACK=tornado PYTHON_VERSION=26
   allow_failures:
     - python: 2.7
-      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore
+      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=27
     - python: 2.6
-      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore
+      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=26
 
 cache:
   - apt
@@ -41,5 +41,5 @@ script:
   - tox
 
 after_success:
-  - source .tox/py27-${MONOCLE_STACK}/bin/activate && py.test -q --confcutdir=.. -n 1 --junitxml=tests/junit.xml --cov-report xml --cov monocle --cov-report=html --cov-report term-missing --pep8
+  - source .tox/py${PYTHON_VERSION}-${MONOCLE_STACK}/bin/activate && py.test -q --confcutdir=.. -n 1 --junitxml=tests/junit.xml --cov-report xml --cov monocle --cov-report=html --cov-report term-missing --pep8
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-{twisted,tornado,asyncore,coverage}
-    py26-{twisted,tornado,asyncore}
+    py26-{twisted26,tornado,asyncore}
     pypy-tornado
 skipsdist = True
 
@@ -14,6 +14,7 @@ deps =
     pypy: cryptography==0.9.3
     tornado: tornado
     twisted: twisted
+    twisted26: twisted<15.5.0
     pyOpenSSL
     pytest
     pytest-cov


### PR DESCRIPTION
added PYTHON_VERSION variable.
activate correct tox virtualenv based on the python version of the travis-ci environment.