### PR TITLE
monocle refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,22 @@
 language: python
 sudo: false
 branches:
-  except:
-    - gh-pages
+  only:
+  - master
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=27
-    - python: 2.7
-      env: TOXENV=py27-tornado MONOCLE_STACK=tornado PYTHON_VERSION=27
-    - python: 2.7
-      env: TOXENV=py27-twisted MONOCLE_STACK=twisted PYTHON_VERSION=27
-    - python: 2.6
-      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=26
-    - python: 2.6
-      env: TOXENV=py26-tornado MONOCLE_STACK=tornado PYTHON_VERSION=26
-    - python: 2.6
-      env: TOXENV=py26-twisted26 MONOCLE_STACK=twisted PYTHON_VERSION=26
-    - python: pypy
-      env: TOXENV=pypy-tornado MONOCLE_STACK=tornado PYTHON_VERSION=26
+    - env: id=latest TOXENV=py27-twisted-latest
+    - env: id=p27-recent TOXENV=py27-twisted-16,py27-twisted-15,py27-twisted-14
+    - env: id=p27-older TOXENV=py27-twisted-13,py27-twisted-12,py27-twisted-11,py27-twisted-10
+    - env: id=p26 TOXENV=py26-twisted-13,py26-twisted-12,py26-twisted-11,py26-twisted-10
+    - env: id=tornado TOXENV=py27-tornado,pypy-tornado
+      python: "pypy-5.3.1"
+    # todo: fix asyncore, or deprecate
+    #- env: id=py27-asyncore TOXENV=py27-asyncore
+    #- env: id=py26-asyncore TOXENV=py26-asyncore
   allow_failures:
-    - python: 2.7
-      env: TOXENV=py27-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=27
-    - python: 2.6
-      env: TOXENV=py26-asyncore MONOCLE_STACK=asyncore PYTHON_VERSION=26
+    - env: id=latest TOXENV=py27-twisted-latest
 
 cache:
   - apt
@@ -39,8 +31,3 @@ install:
 
 script:
   - tox
-
-after_success:
-  - source .tox/py${PYTHON_VERSION}-${MONOCLE_STACK}/bin/activate && py.test -q --confcutdir=.. -n 1 --junitxml=tests/junit.xml --cov-report xml --cov monocle --cov-report=html --cov-report term-missing --pep8
-  - source .tox/py27-${MONOCLE_STACK}/bin/activate && pylint monocle
-

--- a/examples/twisted_client_within_monocle.py
+++ b/examples/twisted_client_within_monocle.py
@@ -1,0 +1,18 @@
+import monocle
+monocle.init('twisted')
+from monocle import _o
+import twisted.web.client
+from monocle.stack import eventloop
+
+# next line breaks the twisted http client in some cases
+import monocle.stack.network.http  # NOQA
+
+
+@_o
+def req():
+    try:
+        yield twisted.web.client.getPage('https://google.com')
+    finally:
+        eventloop.halt()
+monocle.launch(req)
+eventloop.run()

--- a/monocle/stack/network/http.py
+++ b/monocle/stack/network/http.py
@@ -10,7 +10,13 @@ import Cookie
 from functools import wraps
 
 from monocle import _o, Return
-from monocle.stack.network import ConnectionLost, Client, SSLClient
+
+from monocle.stack.network import ConnectionLost, Client
+
+try:
+    from monocle.stack.network import SSLClient
+except:
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -272,7 +278,7 @@ class HttpClient(object):
 
         if scheme == 'http':
             self.client = Client()
-        elif scheme == 'https':
+        elif SSLClient and scheme == 'https':
             self.client = SSLClient()
         else:
             raise HttpException('unsupported url scheme %s' % scheme)

--- a/o_test.py
+++ b/o_test.py
@@ -219,5 +219,8 @@ def main(args):
 if __name__ == '__main__':
     try:
         main(sys.argv[1:])
+    except:
+        traceback.print_exc(file=sys.stdout)
+        raise
     finally:
         sys.exit(_fail_count)

--- a/tox.ini
+++ b/tox.ini
@@ -1,57 +1,50 @@
 [tox]
 envlist =
-    py27-{twisted,tornado,asyncore,coverage}
-    py26-{twisted26,tornado,asyncore}
-    pypy-tornado
+    py27-twisted-{latest,16,15,14,13,12,11,10}
+    py26-twisted-{13,12,11,10}
+    {py27,pypy}-tornado
+# todo: fix asyncore, or deprecate
+#    {py27,py26}-asyncore
 skipsdist = True
 
 [pytest]
 python_files=test_*.py
 
 [testenv]
-passenv = MONOCLE_STACK
 deps =
-    pypy: cryptography==0.9.3
     service_identity
     tornado: tornado
-    twisted: twisted
-    twisted26: twisted<15.5.0
+    twisted-latest: twisted
+    twisted-16: twisted==16.5.0
+    twisted-15: twisted==15.5.0
+    twisted-14: twisted==14.0.2
+    twisted-13: twisted==13.2.0
+    twisted-12: twisted==12.3.0
+    twisted-11: twisted==11.1.0
+    twisted-10: twisted==10.2.0
     pep8
-    pylint
+# todo: setup pylint
+#    pylint
     pyOpenSSL
-    pytest
-    pytest-cov
+# todo: upgrade to pytest3 require code change
+    pytest==2.9.2
+# todo: figure out how to do coverage within o_test
+#    pytest-cov
     pytest-pep8
     pytest-xdist
 
 usedevelop = True
 
 commands =
+    pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
     python o_test.py -v {env:MONOCLE_STACK} tests/
     python examples/basics.py {env:MONOCLE_STACK}
     python examples/client_server.py {env:MONOCLE_STACK}
     python examples/sleep.py {env:MONOCLE_STACK}
     python examples/tb.py {env:MONOCLE_STACK}
-    pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
+    twisted: python examples/twisted_client_within_monocle.py
 
-[testenv:asyncore]
 setenv =
-    MONOCLE_STACK = asyncore
-
-commands =
-    {posargs}
-
-[testenv:tornado]
-setenv =
-    MONOCLE_STACK = tornado
-
-commands = 
-    {posargs}
-
-[testenv:twisted]
-setenv =
-    MONOCLE_STACK = twisted
-
-commands =
-    {posargs}
-
+    twisted: MONOCLE_STACK = twisted
+    tornado: MONOCLE_STACK = tornado
+    asyncore: MONOCLE_STACK = asyncore


### PR DESCRIPTION
@sah could you review

ping @bernii @mher 

Changes:
- disabled TLS monkeypatching for twisted>=11.x, it's not needed
- improved tox setup, no need to pass env variables, added extra config
- improved the travis setup to take advantage of tox
- commented out the coverage, this will need rework
- fix pytest to a version <3 (not backward compatible with o_test.py)
- made SSL optional (not in asyncore)