### PR TITLE
Henry/fix pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Alternatively you can you tox to run all the tests for the different backends:
     ...
     $ tox
 
-Check tox.ini to see you the tests are run.
+Check tox.ini to see how the tests are run.
 
 
 ## Who?

--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ helpful to think of `yield` as in *traffic*.  `yield conn.read(10)` in
 an o-routine means "yield to other o-routines until we finish reading
 10 bytes".
 
+## Developer information
+
+To run individuals tests on your computer install py.test and the packages for
+the backend you’d like to test. Here’s how to do it in a separate virtualenv
+with Twisted:
+
+    $ cd monocle/
+    $ virtualenv --clear --no-site-package .venv
+    $ .venv/bin/pip install pytest twisted
+    ...
+
+You run the tests like this:
+
+    $ .venv/bin/python o_test.py twisted tests/
+
+Alternatively you can you tox to run all the tests for the different backends:
+
+    $ .venv/bin/pip install tox
+    ...
+    $ tox
+
+Check tox.ini to see you the tests are run.
+
+
 ## Who?
 
 Monocle was created by Greg Hazel and Steven Hazel.

--- a/o_test.py
+++ b/o_test.py
@@ -9,6 +9,7 @@ import inspect
 from cStringIO import StringIO
 from functools import partial, wraps
 
+import rewrite
 import monocle
 from monocle import _o, Return
 
@@ -154,8 +155,7 @@ def main(args):
     monocle.init(args.stack)
     from monocle.stack import eventloop
 
-    import rewrite
-    hook = rewrite.AssertionRewritingHook()
+    hook = rewrite.make_assertion_hook()
     sys.meta_path.insert(0, hook)
 
     class State(object):
@@ -217,10 +217,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    try:
-        main(sys.argv[1:])
-    except:
-        traceback.print_exc(file=sys.stdout)
-        raise
-    finally:
-        sys.exit(_fail_count)
+    main(sys.argv[1:])

--- a/rewrite.py
+++ b/rewrite.py
@@ -4,9 +4,17 @@
 import os
 import sys
 import py
-from _pytest.assertion.rewrite import *
-from _pytest.assertion.rewrite import _read_pyc, _rewrite_test, _make_rewritten_pyc
-
+import imp
+import errno
+from _pytest import config
+from _pytest.assertion import install_importhook
+from _pytest.assertion.rewrite import (
+    PYC_TAIL,
+    _read_pyc,
+    _rewrite_test,
+    _make_rewritten_pyc,
+    AssertionRewritingHook,
+)
 
 class AssertionRewritingHook(AssertionRewritingHook):
 
@@ -121,3 +129,8 @@ class AssertionRewritingHook(AssertionRewritingHook):
         finally:
             self.session = sess
         return self
+
+def make_assertion_hook():
+    c = config.get_config()
+    c.parse([])
+    return install_importhook(c)

--- a/rewrite.py
+++ b/rewrite.py
@@ -16,6 +16,7 @@ from _pytest.assertion.rewrite import (
     AssertionRewritingHook,
 )
 
+
 class AssertionRewritingHook(AssertionRewritingHook):
 
     def find_module(self, name, path=None):
@@ -129,6 +130,7 @@ class AssertionRewritingHook(AssertionRewritingHook):
         finally:
             self.session = sess
         return self
+
 
 def make_assertion_hook():
     c = config.get_config()

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,7 @@ deps =
 # todo: setup pylint
 #    pylint
     pyOpenSSL
-# todo: upgrade to pytest3 require code change
-    pytest==2.9.2
+    pytest>=3
 # todo: figure out how to do coverage within o_test
 #    pytest-cov
     pytest-pep8


### PR DESCRIPTION
Add docs on how to run tests

I couldn't run the tests for monocle and I didn't see tox.ini until I was done fixing this. At least now the tests work w/ py.test 3+

@sah 
@saucelabs/connected-cloud