### PR TITLE
Fix tests w/ pytest 3 and add HTTP proxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Alternatively you can you tox to run all the tests for the different backends:
     ...
     $ tox
 
-Check tox.ini to see you the tests are run.
+Check tox.ini to see how the tests are run.
 
 
 ## Who?

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ an o-routine means "yield to other o-routines until we finish reading
 
 ## Developer information
 
-To run individuals tests on your computer install py.test and the packages for
+To run individual tests on your computer install py.test and the packages for
 the backend you’d like to test. Here’s how to do it in a separate virtualenv
 with Twisted:
 
@@ -150,7 +150,7 @@ You run the tests like this:
 
     $ .venv/bin/python o_test.py twisted tests/
 
-Alternatively you can you tox to run all the tests for the different backends:
+Alternatively you can use tox to run all the tests for the different backends:
 
     $ .venv/bin/pip install tox
     ...

--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ helpful to think of `yield` as in *traffic*.  `yield conn.read(10)` in
 an o-routine means "yield to other o-routines until we finish reading
 10 bytes".
 
+## Developer information
+
+To run individuals tests on your computer install py.test and the packages for
+the backend you’d like to test. Here’s how to do it in a separate virtualenv
+with Twisted:
+
+    $ cd monocle/
+    $ virtualenv --clear --no-site-package .venv
+    $ .venv/bin/pip install pytest twisted
+    ...
+
+You run the tests like this:
+
+    $ .venv/bin/python o_test.py twisted tests/
+
+Alternatively you can you tox to run all the tests for the different backends:
+
+    $ .venv/bin/pip install tox
+    ...
+    $ tox
+
+Check tox.ini to see you the tests are run.
+
+
 ## Who?
 
 Monocle was created by Greg Hazel and Steven Hazel.

--- a/examples/twisted_client_within_monocle.py
+++ b/examples/twisted_client_within_monocle.py
@@ -18,12 +18,14 @@ from twisted.internet.endpoints import TCP4ClientEndpoint
 
 url = 'http://google.com'
 
+
 @_o
 def example():
     # Follow HTTP redirects
     agent = RedirectAgent(Agent(reactor))
     response = yield agent.request('GET', url)
     print '{} responded with code {}'.format(url, response.code)
+
 
 @_o
 def proxy_example():
@@ -32,7 +34,7 @@ def proxy_example():
     '''
     endpoint = TCP4ClientEndpoint(reactor, "localhost", 31337)
     agent = ProxyAgent(endpoint)
-    response = yield agent.request('GET', url) # 'http://saucelabs.secret/abc123')
+    response = yield agent.request('GET', url)
     print response.code, response.headers, response.length
 
 run(example)

--- a/examples/twisted_client_within_monocle.py
+++ b/examples/twisted_client_within_monocle.py
@@ -9,12 +9,16 @@ from monocle.script_util import run
 from monocle import _o
 
 from twisted.internet import reactor
-from twisted.web.client import (
-    Agent,
-    ProxyAgent,
-    RedirectAgent,
-)
-from twisted.internet.endpoints import TCP4ClientEndpoint
+try:
+    from twisted.web.client import (
+        Agent,
+        ProxyAgent,
+        RedirectAgent,
+    )
+    from twisted.internet.endpoints import TCP4ClientEndpoint
+except ImportError:
+    print 'This test needs Twisted 11.1+'
+    raise SystemExit()
 
 url = 'http://google.com'
 

--- a/examples/twisted_client_within_monocle.py
+++ b/examples/twisted_client_within_monocle.py
@@ -28,7 +28,7 @@ def example():
     # Follow HTTP redirects
     agent = RedirectAgent(Agent(reactor))
     response = yield agent.request('GET', url)
-    print '{} responded with code {}'.format(url, response.code)
+    print url, 'responded with code', response.code
 
 
 @_o

--- a/examples/twisted_client_within_monocle.py
+++ b/examples/twisted_client_within_monocle.py
@@ -1,14 +1,38 @@
+'''
+This shows how to make HTTP requests using the Twisted HTTP client within
+monocle.
+'''
 import monocle
 monocle.init('twisted')
 from monocle.script_util import run
 
 from monocle import _o
-import twisted.web.client
 
+from twisted.internet import reactor
+from twisted.web.client import (
+    Agent,
+    ProxyAgent,
+    RedirectAgent,
+)
+from twisted.internet.endpoints import TCP4ClientEndpoint
+
+url = 'http://google.com'
 
 @_o
 def example():
-    page = yield twisted.web.client.getPage('https://google.com')
-    print len(page)
+    # Follow HTTP redirects
+    agent = RedirectAgent(Agent(reactor))
+    response = yield agent.request('GET', url)
+    print '{} responded with code {}'.format(url, response.code)
+
+@_o
+def proxy_example():
+    '''
+    make an HTTP request though a proxy running on localhost:31337
+    '''
+    endpoint = TCP4ClientEndpoint(reactor, "localhost", 31337)
+    agent = ProxyAgent(endpoint)
+    response = yield agent.request('GET', url) # 'http://saucelabs.secret/abc123')
+    print response.code, response.headers, response.length
 
 run(example)

--- a/monocle/twisted_stack/network/__init__.py
+++ b/monocle/twisted_stack/network/__init__.py
@@ -6,6 +6,7 @@ from monocle.twisted_stack.eventloop import reactor
 from twisted.internet.protocol import Factory, Protocol, ClientFactory
 from twisted.internet import ssl
 from twisted.internet.error import TimeoutError
+
 from monocle import _o, launch
 from monocle.callback import Callback
 from monocle.stack.network import Connection
@@ -199,7 +200,6 @@ class Client(Connection):
     @_o
     def connect(self, host, port):
         self._connection_timeout = self.timeout
-
         self._stack_conn = _Connection()
         self._stack_conn.attach(self)
         self._stack_conn.connect_cb = Callback()

--- a/monocle/twisted_stack/network/__init__.py
+++ b/monocle/twisted_stack/network/__init__.py
@@ -183,23 +183,6 @@ class SSLContextFactory(ssl.ClientContextFactory):
         return ctx
 
 
-try:
-    from twisted.web.client import ProxyAgent
-    from twisted.internet.endpoints import TCP4ClientEndpoint
-
-    def setup_connection(client, proxy):
-        if proxy:
-            host, port = proxy
-            return ProxyAgent(TCP4ClientEndpoint(client, host, port))
-        else:
-            conn = _Connection()
-            conn.attach(client)
-            return conn
-except ImportError:
-    def setup_connection(client, proxy):
-        raise NotImplementedError(
-            "This version of Twisted doesn't support proxying")
-
 class Client(Connection):
     def __init__(self, *args, **kwargs):
         Connection.__init__(self, *args, **kwargs)
@@ -214,13 +197,11 @@ class Client(Connection):
         self._closed(msg)
 
     @_o
-    def connect(self, host, port, proxy):
-        '''
-        proxy should look like this: ("localhost", 8080)
-        '''
+    def connect(self, host, port):
         self._connection_timeout = self.timeout
 
-        self._stack_conn = setup_connection(self, proxy)
+        self._stack_conn = _Connection()
+        self._stack_conn.attach(self)
         self._stack_conn.connect_cb = Callback()
         factory = ClientFactory()
         factory.protocol = lambda: self._stack_conn

--- a/o_test.py
+++ b/o_test.py
@@ -217,4 +217,10 @@ def main(args):
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    try:
+        main(sys.argv[1:])
+    except:
+        traceback.print_exc(file=sys.stdout)
+        raise
+    finally:
+        sys.exit(_fail_count)

--- a/o_test.py
+++ b/o_test.py
@@ -9,6 +9,7 @@ import inspect
 from cStringIO import StringIO
 from functools import partial, wraps
 
+import rewrite
 import monocle
 from monocle import _o, Return
 
@@ -154,8 +155,7 @@ def main(args):
     monocle.init(args.stack)
     from monocle.stack import eventloop
 
-    import rewrite
-    hook = rewrite.AssertionRewritingHook()
+    hook = rewrite.make_assertion_hook()
     sys.meta_path.insert(0, hook)
 
     class State(object):
@@ -217,10 +217,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    try:
-        main(sys.argv[1:])
-    except:
-        traceback.print_exc(file=sys.stdout)
-        raise
-    finally:
-        sys.exit(_fail_count)
+    main(sys.argv[1:])

--- a/rewrite.py
+++ b/rewrite.py
@@ -4,9 +4,17 @@
 import os
 import sys
 import py
-from _pytest.assertion.rewrite import *
-from _pytest.assertion.rewrite import _read_pyc, _rewrite_test, _make_rewritten_pyc
-
+import imp
+import errno
+from _pytest import config
+from _pytest.assertion import install_importhook
+from _pytest.assertion.rewrite import (
+    PYC_TAIL,
+    _read_pyc,
+    _rewrite_test,
+    _make_rewritten_pyc,
+    AssertionRewritingHook,
+)
 
 class AssertionRewritingHook(AssertionRewritingHook):
 
@@ -121,3 +129,8 @@ class AssertionRewritingHook(AssertionRewritingHook):
         finally:
             self.session = sess
         return self
+
+def make_assertion_hook():
+    c = config.get_config()
+    c.parse([])
+    return install_importhook(c)

--- a/rewrite.py
+++ b/rewrite.py
@@ -16,6 +16,7 @@ from _pytest.assertion.rewrite import (
     AssertionRewritingHook,
 )
 
+
 class AssertionRewritingHook(AssertionRewritingHook):
 
     def find_module(self, name, path=None):
@@ -129,6 +130,7 @@ class AssertionRewritingHook(AssertionRewritingHook):
         finally:
             self.session = sess
         return self
+
 
 def make_assertion_hook():
     c = config.get_config()

--- a/tests/stack_network_http.py
+++ b/tests/stack_network_http.py
@@ -5,6 +5,7 @@ from monocle import _o, Return
 from monocle.stack import network
 from monocle.stack.network import http
 
+
 @_o
 def default_handler(conn):
     data = 'Hello, World!'
@@ -13,6 +14,7 @@ def default_handler(conn):
     headers.add('Content-Type', 'text/plain')
     headers.add('Connection', 'close')
     yield Return(200, headers, data)
+
 
 @contextmanager
 def http_server_running(port, handler=default_handler):

--- a/tests/stack_network_http.py
+++ b/tests/stack_network_http.py
@@ -67,8 +67,3 @@ def test_large_requests():
             send_body = 'x' * 1024 * 1024 * 10
             r = yield client.request('/', method='POST', body='x' * 1024 * 1024 * 10)
             assert recv_body[0] == send_body
-
-
-@test
-@_o
-def test_proxy():

--- a/tests/stack_network_http.py
+++ b/tests/stack_network_http.py
@@ -5,19 +5,17 @@ from monocle import _o, Return
 from monocle.stack import network
 from monocle.stack.network import http
 
+@_o
+def default_handler(conn):
+    data = 'Hello, World!'
+    headers = http.HttpHeaders()
+    headers.add('Content-Length', len(data))
+    headers.add('Content-Type', 'text/plain')
+    headers.add('Connection', 'close')
+    yield Return(200, headers, data)
 
 @contextmanager
-def http_server_running(port, handler=None):
-    @_o
-    def _handler(conn):
-        data = 'Hello, World!'
-        headers = http.HttpHeaders()
-        headers.add('Content-Length', len(data))
-        headers.add('Content-Type', 'text/plain')
-        headers.add('Connection', 'close')
-        yield Return(200, headers, data)
-    if not handler:
-        handler = _handler
+def http_server_running(port, handler=default_handler):
     service = http.HttpServer(port, handler=handler)
     network.add_service(service)
     try:
@@ -69,3 +67,8 @@ def test_large_requests():
             send_body = 'x' * 1024 * 1024 * 10
             r = yield client.request('/', method='POST', body='x' * 1024 * 1024 * 10)
             assert recv_body[0] == send_body
+
+
+@test
+@_o
+def test_proxy():

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 usedevelop = True
 
 commands =
-    # pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
+    pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
     python o_test.py -v {env:MONOCLE_STACK} tests/
     python examples/basics.py {env:MONOCLE_STACK}
     python examples/client_server.py {env:MONOCLE_STACK}

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 usedevelop = True
 
 commands =
-    pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
+    # pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
     python o_test.py -v {env:MONOCLE_STACK} tests/
     python examples/basics.py {env:MONOCLE_STACK}
     python examples/client_server.py {env:MONOCLE_STACK}

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,7 @@ deps =
 # todo: setup pylint
 #    pylint
     pyOpenSSL
-# todo: upgrade to pytest3 require code change
-    pytest==2.9.2
+    pytest>=3
 # todo: figure out how to do coverage within o_test
 #    pytest-cov
     pytest-pep8


### PR DESCRIPTION
I fixed the monocle tests to run correctly with pytest 3, and I added a function in the examples on how to make an HTTP request using a proxy with Twisted's HTTP client.

https://saucedev.atlassian.net/browse/SC-794

No functionality change, I just needed to figure out how to do it =)

@sah 
@saucelabs/connected-cloud 