### PR TITLE
add tests/examples for monocle_mock using patch and side_effect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,19 @@ branches:
 
 matrix:
   include:
-    - env: id=latest TOXENV=py27-twisted-latest
-    - env: id=p27-recent TOXENV=py27-twisted-16,py27-twisted-15,py27-twisted-14
-    - env: id=p27-older TOXENV=py27-twisted-13,py27-twisted-12,py27-twisted-11,py27-twisted-10
-    - env: id=p26 TOXENV=py26-twisted-13,py26-twisted-12,py26-twisted-11,py26-twisted-10
-    - env: id=tornado TOXENV=py27-tornado,pypy-tornado
-      python: "pypy-5.3.1"
+    - python: 2.7
+      env: id=latest TOXENV=py27-twisted-latest
+    - python: 2.7
+      env: id=p27-recent TOXENV=py27-twisted-16,py27-twisted-15,py27-twisted-14
+    - python: 2.7
+      env: id=p27-older TOXENV=py27-twisted-13,py27-twisted-12,py27-twisted-11,py27-twisted-10
+    - python: 2.7
+      env: id=p27-tornado TOXENV=py27-tornado
+    - python: 2.6
+      env: id=p26 TOXENV=py26-twisted-13,py26-twisted-12,py26-twisted-11,py26-twisted-10
+    - python: "pypy-5.3.1"
+      env: id=pypy-tornado TOXENV=pypy-tornado
+
     # todo: fix asyncore, or deprecate
     #- env: id=py27-asyncore TOXENV=py27-asyncore
     #- env: id=py26-asyncore TOXENV=py26-asyncore

--- a/tests/monocle_mock.py
+++ b/tests/monocle_mock.py
@@ -1,6 +1,8 @@
 from monocle import _o, Return
 from monocle.monocle_mock import MonocleMock, MagicMonocleMock
 
+from mock import patch
+
 from o_test import test
 
 
@@ -27,6 +29,34 @@ def test_assert_called_with():
     mock = MonocleMock()
     yield mock('an arg', 'another arg')
     mock.assert_called_once_with('an arg', 'another arg')
+
+
+@test
+@_o
+def test_side_effect():
+    mock = MonocleMock()
+    mock.side_effect = Exception('a side effect')
+    try:
+        yield mock()
+    except Exception as e:
+        assert 'a side effect' == e.message
+        yield Return(None)
+    assert False, "expected exception"
+
+
+@_o
+def mock_me():
+    return 'original result'
+
+
+@test
+@_o
+def test_patch():
+    with patch('monocle_mock.mock_me', new=MagicMonocleMock()) as mock:
+        mock.return_value = 'mocked result'
+        result = yield mock_me()
+        assert not isinstance(result, MagicMonocleMock)
+        assert result == 'mocked result'
 
 
 @test

--- a/tests/monocle_mock.py
+++ b/tests/monocle_mock.py
@@ -60,6 +60,17 @@ def test_patch():
 
 
 @test
+@patch('monocle_mock.mock_me', new_callable=MagicMonocleMock)
+@_o
+def test_patch_decorator(mock):
+    # @patch must wrap/preceed @_o
+    mock.return_value = 'mocked result'
+    result = yield mock_me()
+    assert not isinstance(result, MagicMonocleMock)
+    assert result == 'mocked result'
+
+
+@test
 @_o
 def test_str():
     def assert_str_and_repr_start_with(mock, expected):


### PR DESCRIPTION
Adds a couple tests that describe how to use side_effect and patch with MonocleMock.

Also fixes a travis issue with python 2.6 (`InterpreterNotFound: python2.6`) that seems to have spontaneously started in master [build here](https://travis-ci.org/saucelabs/monocle/builds/276982079). There are no recent changes to .travis.yml, so I'm assuming something changed on the travis side.