### PR TITLE
Remove root logger handler

### DIFF
--- a/monocle/core.py
+++ b/monocle/core.py
@@ -21,8 +21,6 @@ except ImportError:
     class TwistedDeferred:
         pass
 
-logging.basicConfig(stream=sys.stderr,
-                    format="%(message)s")
 log = logging.getLogger("monocle")
 
 blocking_warn_threshold = 500  # ms


### PR DESCRIPTION
Since monocle is used as a library, we should let the calling application  define the log handlers. logging.basicConfig adds a handler to the root logger, which can cause unexpected duplicate logs
to appear in calling application. Remove it, and let the calling application define handlers for monocle if necessary.