### PR TITLE
Linting: Update to fix E722 & E741, update to pycodestyle

### DIFF
--- a/monocle/script_util.py
+++ b/monocle/script_util.py
@@ -12,7 +12,7 @@ def run(fn):
     def _run_async(ctx):
         try:
             yield fn()
-        except:
+        except Exception:
             traceback.print_exc(file=sys.stdout)
             ctx['exit_code'] = 1
         finally:

--- a/monocle/stack/multiprocess/__init__.py
+++ b/monocle/stack/multiprocess/__init__.py
@@ -36,9 +36,9 @@ class SocketChannel(object):
 
     @_o
     def recv(self):
-        l = yield self.conn.readline()
-        l = int(l)
-        p = yield self.conn.read(l)
+        line = yield self.conn.readline()
+        line = int(line)
+        p = yield self.conn.read(line)
         value = pickle.loads(p)
         yield Return(value)
 

--- a/monocle/stack/multiprocess/sync.py
+++ b/monocle/stack/multiprocess/sync.py
@@ -75,14 +75,14 @@ class SyncSockChannel(object):
         self._sendall(p)
 
     def recv(self):
-        l = ""
+        line = ""
         while True:
             x = self._recv(1)
             if x == "\n":
                 break
-            l += x
-        l = int(l)
-        p = self._recv(l)
+            line += x
+        line = int(line)
+        p = self._recv(line)
         try:
             value = pickle.loads(p)
         except Exception:
@@ -124,9 +124,7 @@ class SockChannelHandler(logging.Handler):
     def emit(self, record):
         try:
             self.send(record)
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except:
+        except Exception:
             self.handleError(record)
 
     def close(self):
@@ -223,9 +221,7 @@ class PipeHandler(logging.Handler):
     def emit(self, record):
         try:
             self.send(record)
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except:
+        except Exception:
             self.handleError(record)
 
     def close(self):

--- a/monocle/stack/network/http.py
+++ b/monocle/stack/network/http.py
@@ -12,7 +12,7 @@ from monocle.stack.network import ConnectionLost, Client
 
 try:
     from monocle.stack.network import SSLClient
-except:
+except Exception:
     pass
 
 log = logging.getLogger(__name__)

--- a/monocle/tornado_stack/network/http.py
+++ b/monocle/tornado_stack/network/http.py
@@ -59,7 +59,7 @@ class HttpServer(Service, HttpRouter):
 
                 value = yield launch(self.handle_request, request)
                 code, headers, content = extract_response(value)
-            except:
+            except Exception:
                 code, headers, content = 500, {}, "500 Internal Server Error"
             tornado_request.write("HTTP/1.1 %s %s\r\n" %
                                   (code, responses.get(code, 'Unknown')))

--- a/monocle/twisted_stack/eventloop.py
+++ b/monocle/twisted_stack/eventloop.py
@@ -9,15 +9,15 @@ if 'twisted.internet.reactor' not in sys.modules:
     try:
         from twisted.internet import epollreactor
         epollreactor.install()
-    except:
+    except Exception:
         try:
             from twisted.internet import kqreactor
             kqreactor.install()
-        except:
+        except Exception:
             try:
                 from twisted.internet import pollreactor
                 pollreactor.install()
-            except:
+            except Exception:
                 pass
 
 from twisted.internet import reactor

--- a/o_test.py
+++ b/o_test.py
@@ -220,7 +220,7 @@ def main(args):
 if __name__ == '__main__':
     try:
         main(sys.argv[1:])
-    except:
+    except BaseException:
         traceback.print_exc(file=sys.stdout)
         raise
     finally:

--- a/tox.ini
+++ b/tox.ini
@@ -22,20 +22,19 @@ deps =
     twisted-12: twisted==12.3.0
     twisted-11: twisted==11.1.0
     twisted-10: twisted==10.2.0
-    pep8
+    pycodestyle
 # todo: setup pylint
 #    pylint
     pyOpenSSL
     pytest>=3
 # todo: figure out how to do coverage within o_test
 #    pytest-cov
-    pytest-pep8
     pytest-xdist
 
 usedevelop = True
 
 commands =
-    pep8 --ignore='E125,E129,E265,E402,E501,E731,W291,W293'
+    pycodestyle --ignore='E125,E129,E265,E302,E305,E402,E501,E731,W291,W293'
     python o_test.py -v {env:MONOCLE_STACK} tests/
     python examples/basics.py {env:MONOCLE_STACK}
     python examples/client_server.py {env:MONOCLE_STACK}


### PR DESCRIPTION
Both checkers are added in newer versions of pycodestyle (formerly known as pep8)  Should have no functional changes, but prevent jenkins from failing with a newer version of pep8/pycodestyle

E722: do not use bare except
E741: ambiguous variable name

Also update pep8 to pycodestyle.

@sah @sebv @lukmdo 